### PR TITLE
Refactor-powerup

### DIFF
--- a/ShmupSandbox/Autoloads/game_manager.gd
+++ b/ShmupSandbox/Autoloads/game_manager.gd
@@ -27,6 +27,12 @@ const life_extend_score_2 : int = 250000
 const score_penallty_multiplier : float = 0.9
 const player_default_bombs : int = 3
 const player_max_bombs : int = 9
+const min_bounds : Vector2 = Vector2(0, 0)
+
+## Offsets for screen bounds
+const offset_x : float = 60.0
+const offset_y_screen_bottom : float = 60.0
+const offset_y_screen_top : float = 100.0
 
 enum powerups {
 	None,			## 0

--- a/ShmupSandbox/Helpers/helper.gd
+++ b/ShmupSandbox/Helpers/helper.gd
@@ -29,7 +29,10 @@ static func clamp_movement_to_screen_bounds(
 
     return position
 
-## TODO: update all scripts that set timer properties to use this func
+
+################################################
+# NOTE: Setting timer properties
+################################################
 static func set_timer_properties(timer : Timer, one_shot : bool, wait_time: float) -> void:
     timer.one_shot = one_shot
     timer.wait_time = wait_time

--- a/ShmupSandbox/Helpers/helper.gd
+++ b/ShmupSandbox/Helpers/helper.gd
@@ -2,37 +2,50 @@ class_name Helper extends Object
 
 ################################################
 # NOTE: Helpfer function class:
-    # Holds all common helper functions
+	# Holds all common helper functions
 ################################################
 
 ################################################
 # NOTE: Limit movement to screen bounds
 ################################################
-static func clamp_movement_to_screen_bounds(
-                                            viewport_size : Vector2, 
-                                            position : Vector2, 
-                                            x_clamp : bool, 
-                                            y_clamp : bool
-                                            ) -> Vector2:
-    # Clamp position within bounds
-    const min_bounds : Vector2 = Vector2(0, 0)
-    var max_bounds : Vector2 = viewport_size
-    const offset_x : float = 60.0
-    const offset_y_screen_bottom : float = 60.0
-    const offset_y_screen_top : float = 100.0
+static func clamp_movement_to_screen_bounds(viewport_size : Vector2, position : Vector2, x_clamp : bool, y_clamp : bool) -> Vector2:
+	# Clamp position within bounds
+	var max_bounds : Vector2 = viewport_size
 
-    if x_clamp:
-        position.x = clamp(position.x, offset_x - min_bounds.x, max_bounds.x - offset_x)
-    
-    if y_clamp:
-        position.y = clamp(position.y, offset_y_screen_top + min_bounds.y, max_bounds.y - offset_y_screen_bottom)
+	if x_clamp:
+		position.x = clamp(
+			position.x, 
+			GameManager.offset_x - GameManager.min_bounds.x, 
+			max_bounds.x - GameManager.offset_x
+			)
+	
+	if y_clamp:
+		position.y = clamp(
+			position.y, 
+			GameManager.offset_y_screen_top + GameManager.min_bounds.y, 
+			max_bounds.y - GameManager.offset_y_screen_bottom
+			)
 
-    return position
+	return position
 
 
 ################################################
 # NOTE: Setting timer properties
 ################################################
 static func set_timer_properties(timer : Timer, one_shot : bool, wait_time: float) -> void:
-    timer.one_shot = one_shot
-    timer.wait_time = wait_time
+	timer.one_shot = one_shot
+	timer.wait_time = wait_time
+
+
+################################################
+# NOTE: Setting direction with arguments
+################################################
+static func set_direction(viewport_size : Vector2, origin : Vector2, target : Vector2 = Vector2.ZERO, random : bool = true) -> Vector2:
+	if random:
+		var rand_x : float = randf_range(0, viewport_size.x)
+		var rand_y : float = randf_range(0, viewport_size.y)
+		target = Vector2(rand_x, rand_y)
+	
+	var direction : Vector2 = origin.direction_to(target).normalized()
+	
+	return direction

--- a/ShmupSandbox/Pickups/Scenes/pickup_powerup.tscn
+++ b/ShmupSandbox/Pickups/Scenes/pickup_powerup.tscn
@@ -1,18 +1,11 @@
-[gd_scene load_steps=61 format=3 uid="uid://drn1oajqy3684"]
+[gd_scene load_steps=59 format=3 uid="uid://drn1oajqy3684"]
 
 [ext_resource type="Script" uid="uid://85opciapqat8" path="res://ShmupSandbox/Pickups/Scripts/pickup_powerup.gd" id="1_8m5pr"]
-[ext_resource type="Script" uid="uid://dlh7lg7gj4tlp" path="res://ShmupSandbox/Pickups/Scripts/powerup_pathfollow.gd" id="1_glbyy"]
 [ext_resource type="Texture2D" uid="uid://banrdqkgowv87" path="res://ShmupSandbox/Assets/Pickups/od-v1.png" id="3_8m5pr"]
 [ext_resource type="Texture2D" uid="uid://bvjfrhgvvsyed" path="res://ShmupSandbox/Assets/Pickups/ch-v1.png" id="4_haqd0"]
 [ext_resource type="Texture2D" uid="uid://cd0otonekhged" path="res://ShmupSandbox/Assets/Pickups/fx-v1.png" id="4_p0ehi"]
 [ext_resource type="Texture2D" uid="uid://cpct0bw2yeirq" path="res://ShmupSandbox/Assets/Pickups/fz-v1.png" id="5_67wdi"]
 [ext_resource type="FontFile" uid="uid://chyk1vw521kif" path="res://ShmupSandbox/Assets/Fonts/Metal Lord.otf" id="6_aa45h"]
-
-[sub_resource type="Curve2D" id="Curve2D_haqd0"]
-_data = {
-"points": PackedVector2Array(0, 0, 0, 0, -1, -1, -20.4187, -2.52876, 20.4187, 2.52876, 45.3676, -17.6719, 0.466507, -14.9282, -0.466507, 14.9282, 94, 39, 19.5933, -14.9282, -19.5933, 14.9282, 73, 80, 20.5263, 8.86364, -20.5263, -8.86364, 14, 91, 3.73206, 19.1268, -3.73206, -19.1268, -16, 47, 0, 0, 0, 0, -1, -1)
-}
-point_count = 7
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_lkxkw"]
 radius = 32.0
@@ -401,72 +394,59 @@ animations = [{
 "speed": 12.0
 }]
 
-[node name="PickupPowerup" type="Node2D"]
+[node name="PickupPowerup" type="Area2D"]
+collision_layer = 32
 script = ExtResource("1_8m5pr")
 speed = 30.0
 powerup_switch_time = 2.0
 
-[node name="powerup_switch_timer" type="Timer" parent="."]
-
-[node name="path" type="Path2D" parent="."]
-self_modulate = Color(1, 1, 0, 1)
-position = Vector2(2.82641, 2.63921)
-scale = Vector2(1.17206, 1.16791)
-curve = SubResource("Curve2D_haqd0")
-
-[node name="pathfollow" type="PathFollow2D" parent="path"]
-unique_name_in_owner = true
-position = Vector2(-1, -1)
-scale = Vector2(1.00565, 1)
-rotates = false
-script = ExtResource("1_glbyy")
-pathfollow_speed = 0.2
-
-[node name="powerup_area" type="Area2D" parent="path/pathfollow"]
-unique_name_in_owner = true
+[node name="collider" type="CollisionShape2D" parent="."]
+position = Vector2(1.65435, 1.4713)
 rotation = -1.5708
-collision_layer = 32
-
-[node name="collider" type="CollisionShape2D" parent="path/pathfollow/powerup_area"]
+scale = Vector2(1.16791, 1.17868)
 shape = SubResource("CircleShape2D_lkxkw")
 debug_color = Color(1, 0.639216, 0.121569, 0.172549)
 
-[node name="sprite_od" type="AnimatedSprite2D" parent="path/pathfollow"]
+[node name="sprite_od" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
-scale = Vector2(1.5, 1.5)
+position = Vector2(1.65435, 1.4713)
+scale = Vector2(1.76802, 1.75186)
 sprite_frames = SubResource("SpriteFrames_t0yqe")
 animation = &"collect"
 autoplay = "idle"
 
-[node name="sprite_ch" type="AnimatedSprite2D" parent="path/pathfollow"]
+[node name="sprite_ch" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 visible = false
-scale = Vector2(1.5, 1.5)
+position = Vector2(1.65435, 1.4713)
+scale = Vector2(1.76802, 1.75186)
 sprite_frames = SubResource("SpriteFrames_cu70m")
 animation = &"collect"
 autoplay = "idle"
 
-[node name="sprite_fz" type="AnimatedSprite2D" parent="path/pathfollow"]
+[node name="sprite_fz" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 visible = false
-scale = Vector2(1.5, 1.5)
+position = Vector2(1.65435, 1.4713)
+scale = Vector2(1.76802, 1.75186)
 sprite_frames = SubResource("SpriteFrames_60c7r")
 animation = &"collect"
 autoplay = "idle"
 
-[node name="sprite_fx" type="AnimatedSprite2D" parent="path/pathfollow"]
+[node name="sprite_fx" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
-scale = Vector2(1.5, 1.5)
+position = Vector2(1.65435, 1.4713)
+scale = Vector2(1.76802, 1.75186)
 sprite_frames = SubResource("SpriteFrames_edng5")
 animation = &"idle"
 autoplay = "idle"
 
-[node name="powerup_label" type="Label" parent="path/pathfollow"]
+[node name="powerup_label" type="Label" parent="."]
 unique_name_in_owner = true
-offset_left = -61.6403
-offset_top = -40.6464
-offset_right = 62.3597
-offset_bottom = -9.6464
+offset_left = -71.0
+offset_top = -46.0
+offset_right = 53.0
+offset_bottom = -15.0
 theme_override_colors/font_outline_color = Color(0.133333, 0.137255, 0.137255, 1)
 theme_override_constants/outline_size = 6
 theme_override_fonts/font = ExtResource("6_aa45h")
@@ -475,9 +455,11 @@ text = "Overdrive"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
-position = Vector2(126, 51)
+[node name="powerup_switch_timer" type="Timer" parent="."]
 
+[node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
+position = Vector2(64, 0)
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="powerup_switch_timer" to="." method="_on_powerup_switch_timer_timeout"]
-[connection signal="body_entered" from="path/pathfollow/powerup_area" to="." method="_on_powerup_area_body_entered"]
 [connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="_on_visible_on_screen_notifier_2d_screen_exited"]

--- a/ShmupSandbox/Pickups/Scenes/pickup_powerup.tscn
+++ b/ShmupSandbox/Pickups/Scenes/pickup_powerup.tscn
@@ -397,7 +397,6 @@ animations = [{
 [node name="PickupPowerup" type="Area2D"]
 collision_layer = 32
 script = ExtResource("1_8m5pr")
-speed = 30.0
 powerup_switch_time = 2.0
 
 [node name="collider" type="CollisionShape2D" parent="."]
@@ -457,9 +456,12 @@ vertical_alignment = 1
 
 [node name="powerup_switch_timer" type="Timer" parent="."]
 
+[node name="move_timer" type="Timer" parent="."]
+
 [node name="VisibleOnScreenNotifier2D" type="VisibleOnScreenNotifier2D" parent="."]
 position = Vector2(64, 0)
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="timeout" from="powerup_switch_timer" to="." method="_on_powerup_switch_timer_timeout"]
+[connection signal="timeout" from="move_timer" to="." method="_on_move_timer_timeout"]
 [connection signal="screen_exited" from="VisibleOnScreenNotifier2D" to="." method="_on_visible_on_screen_notifier_2d_screen_exited"]

--- a/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
+++ b/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
@@ -1,6 +1,7 @@
 class_name PickupPowerup extends Area2D
 
 @onready var powerup_switch_timer : Timer = $powerup_switch_timer
+@onready var move_timer : Timer = $move_timer
 @onready var sprite_fx : AnimatedSprite2D = %sprite_fx
 @onready var sprite_od: AnimatedSprite2D = %sprite_od
 @onready var sprite_ch : AnimatedSprite2D = %sprite_ch
@@ -8,8 +9,12 @@ class_name PickupPowerup extends Area2D
 @onready var powerup_label : Label = %powerup_label
 @onready var collider_area : Area2D = %powerup_area
 
-@export var speed : float = 20
+@export var base_speed_x: float = 7.5
+@export var base_speed_y : float = 50
+@export var spawn_speed : float = 500.0
+@export var deceleration : float = 1000.0
 @export var powerup_switch_time : float = 5.5
+@export var move_time : float = 0.1
 @export var powerup_score : int = 1000 # Player gets score if current powerup level is maxed out
 
 const idle_anim : String = "idle"
@@ -22,27 +27,43 @@ var current_powerup_sprite : AnimatedSprite2D
 var viewport_size : Vector2
 var sprites_list : Array[AnimatedSprite2D] = []
 
-## TODO: Update movement logic
-	# Initial spawn: use similar logic to score item:
-		# - explode towards center of screen
-	# Get rid of path, make it an area2d
-	# Move vertically up and down the screen within y bounds
-	# Move horizontally from right to left
+var direction : Vector2
+var velocity : Vector2
+var idle_state : bool
+
 
 ################################################
 #NOTE: Ready
 ################################################
 func _ready() -> void:
+	# Get viewport size
 	viewport_size = get_viewport_rect().size
+	
+	# Set powerup label to be invisible
 	powerup_label.visible = false
 
+	# Create poowerups list/array
 	powerups_array = GameManager.powerups.values().slice(1, GameManager.powerups.size())	# Ignore the "None" index in that enum
 	
+	# Set timer properties and start timers
 	Helper.set_timer_properties(powerup_switch_timer, false, powerup_switch_time)
+	Helper.set_timer_properties(move_timer, true, move_time)
 	powerup_switch_timer.start()
+	move_timer.start()
 
+	# Create list of sprites
 	_create_sprites_list()
+
+	# Select a random powerup to be active on spawn
 	_random_powerup_on_spawn()
+
+	# Set initial spawn movement direction
+	var screen_ceter : Vector2 = Vector2(viewport_size.x/2, viewport_size.y/2)
+	direction = Helper.set_direction(viewport_size, self.global_position, screen_ceter, false)
+	
+	# Set spawn velocity
+	velocity = spawn_speed * direction
+
 
 ## Create the array of powerups, ignore the fx sprite
 func _create_sprites_list() -> void:
@@ -74,27 +95,33 @@ func _toggle_powerup_sprite() -> void:
 			powerup_sprite.visible = false
 			powerup_sprite.stop()
 
+
 ################################################
 #NOTE: Physics process
 ################################################
 func _physics_process(delta: float) -> void:
-	global_position.x -= speed * delta
+	if idle_state:
+		# Movement when in idle state
+		# Move slowly from right to left while moving up and down the screen
+		var vel_x : float = base_speed_x * Vector2.LEFT.x
+		var vel_y : float = base_speed_y * direction.y
+		var vel : Vector2 = Vector2(vel_x, vel_y)
+		velocity = velocity.move_toward(vel, deceleration * delta)
+	
+	global_position += velocity * delta
 
 
 ################################################
 #NOTE: Process
 ################################################
 func _process(_delta: float) -> void:
-	_clamp_movement_to_screen_y_bounds()
+	position = Helper.clamp_movement_to_screen_bounds(viewport_size, position, false, true)
 
-func _clamp_movement_to_screen_y_bounds() -> void:
-	# Clamp position within bounds
-	var min_bounds : Vector2 = Vector2(0, 0)
-	var max_bounds : Vector2 = viewport_size
-	var offset_y_screen_bottom : float = 50.0
-	var offset_y_screen_top : float = 50.0
-	
-	position.y = clamp(position.y, offset_y_screen_top + min_bounds.y, max_bounds.y - offset_y_screen_bottom)
+	# Switch y direction if hitting upper or lower screen bounds
+	if position.y <= GameManager.offset_y_screen_top:
+		direction = Vector2.DOWN
+	elif position.y >= viewport_size.y - GameManager.offset_y_screen_bottom:
+		direction = Vector2.UP
 
 
 ################################################
@@ -135,7 +162,7 @@ func _on_body_entered(body:Node2D) -> void:
 		set_deferred("monitoring", false)
 
 		## Stop on collection
-		speed = 0
+		direction = Vector2.ZERO
 
 		## Turn off powerup switch timer
 		powerup_switch_timer.stop()
@@ -191,3 +218,11 @@ func _play_collect_anims_for_label() -> Tween:
 	tween.tween_property(powerup_label, "self_modulate", UiUtility.color_transparent, 0.7) # Fade out effect
 
 	return tween
+
+
+################################################
+#NOTE: Set to idle state after initial spawn explosion movement
+################################################
+func _on_move_timer_timeout() -> void:
+	idle_state = true
+	direction = Vector2.UP

--- a/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
+++ b/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
@@ -24,6 +24,12 @@ var current_powerup_sprite : AnimatedSprite2D
 var viewport_size : Vector2
 var sprites_list : Array[AnimatedSprite2D] = []
 
+## TODO: Update movement logic
+	# Initial spawn: use similar logic to score item:
+		# - explode towards center of screen
+	# Get rid of path, make it an area2d
+	# Move vertically up and down the screen within y bounds
+	# Move horizontally from right to left
 
 ################################################
 #NOTE: Ready

--- a/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
+++ b/ShmupSandbox/Pickups/Scripts/pickup_powerup.gd
@@ -1,4 +1,4 @@
-class_name PickupPowerup extends Node2D
+class_name PickupPowerup extends Area2D
 
 @onready var powerup_switch_timer : Timer = $powerup_switch_timer
 @onready var sprite_fx : AnimatedSprite2D = %sprite_fx
@@ -7,8 +7,6 @@ class_name PickupPowerup extends Node2D
 @onready var sprite_fz : AnimatedSprite2D = %sprite_fz
 @onready var powerup_label : Label = %powerup_label
 @onready var collider_area : Area2D = %powerup_area
-
-@onready var sprites_container : PathFollow2D = %pathfollow
 
 @export var speed : float = 20
 @export var powerup_switch_time : float = 5.5
@@ -48,7 +46,7 @@ func _ready() -> void:
 
 ## Create the array of powerups, ignore the fx sprite
 func _create_sprites_list() -> void:
-	for node : Node in sprites_container.get_children():
+	for node : Node in get_children():
 		if node is AnimatedSprite2D && node != sprite_fx:
 			sprites_list.append(node)
 
@@ -117,23 +115,27 @@ func _switch_powerup() -> void:
 
 
 ################################################
-#NOTE: Despawn when exiting screen left
+#NOTE: Despawn after exiting screen
 ################################################
 func _on_visible_on_screen_notifier_2d_screen_exited() -> void:
-	queue_free()
+	call_deferred("queue_free")
 
 
 ################################################
 #NOTE: Logic for when powerup is collected by player
 ################################################
-func _on_powerup_area_body_entered(body:Node2D) -> void:
+func _on_body_entered(body:Node2D) -> void:
 	if body is PlayerCat:
+		## Do nothing if the player is dead
+		if body.is_dead:
+			return
+		
 		## Disable collider area on collection
-		collider_area.set_deferred("monitorable", false)
-		collider_area.set_deferred("monitoring", false)
+		set_deferred("monitorable", false)
+		set_deferred("monitoring", false)
 
-		## Stop the path follow movement on collection
-		sprites_container.pathfollow_speed = 0.0
+		## Stop on collection
+		speed = 0
 
 		## Turn off powerup switch timer
 		powerup_switch_timer.stop()

--- a/ShmupSandbox/Pickups/Scripts/pickup_score.gd
+++ b/ShmupSandbox/Pickups/Scripts/pickup_score.gd
@@ -52,7 +52,7 @@ func _ready() -> void:
 	_create_item_collider_map()
 	_set_current_item()
 	_connect_to_signals()
-	_set_initial_direction()
+	direction = Helper.set_direction(viewport_size, self.global_position)
 	
 	Helper.set_timer_properties(move_timer, true, move_time)
 	move_timer.start()
@@ -117,16 +117,6 @@ func _on_player_death_event() -> void:
 	# Despawn on player death
 	# TODO: Despawn animations
 	call_deferred("queue_free")
-
-
-################################################
-#NOTE: Set direction to move on spawn
-################################################
-func _set_initial_direction() -> void:
-	var rand_x : float = randf_range(0, viewport_size.x)
-	var rand_y : float = randf_range(0, viewport_size.y)
-	var rand_vector : Vector2 = Vector2(rand_x, rand_y)
-	direction = self.global_position.direction_to(rand_vector).normalized()
 
 
 ################################################

--- a/ShmupSandbox/Player/Scripts/player_cat.gd
+++ b/ShmupSandbox/Player/Scripts/player_cat.gd
@@ -94,7 +94,6 @@ func _unhandled_input(event: InputEvent) -> void:
 		SignalsBus.player_pressed_pause_game_event.emit()
 
 
-## TODO: Add signal to spawn a powerup
 ################################################
 # NOTE: Hurtbox signal
 # Handle getting hit by enemies or projectiles
@@ -111,6 +110,8 @@ func _on_hurtbox_area_entered(_area: Area2D) -> void:
 	
 	rocket.visible = false # Contains body and thruster sprites
 	death.play("death")
+
+	SignalsBus.spawn_powerup_event.emit(self.global_position)	
 	
 	await death.animation_finished
 	

--- a/ShmupSandbox/Player/Scripts/player_cat.gd
+++ b/ShmupSandbox/Player/Scripts/player_cat.gd
@@ -94,7 +94,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		SignalsBus.player_pressed_pause_game_event.emit()
 
 
-
+## TODO: Add signal to spawn a powerup
 ################################################
 # NOTE: Hurtbox signal
 # Handle getting hit by enemies or projectiles


### PR DESCRIPTION
- powerup movement logic updated
- on spawn pwerup "explodes" toward screen center
- after this it goes to base/idle state and moves slowly to the right while moveing up and down the screen (similar to viper phase 1)
- player drops powerup on death